### PR TITLE
Fullscreen mode

### DIFF
--- a/src/js/modules/webslides.js
+++ b/src/js/modules/webslides.js
@@ -423,8 +423,8 @@ export default class WebSlides {
   fullscreen() {
     const el = document.documentElement;
     const isFullscreen = document.fullscreen
-      || document.mozFullScreen
       || document.webkitIsFullScreen
+      || document.mozFullScreen
       || document.msFullScreenElement;
 
     if(!isFullscreen) {
@@ -435,8 +435,8 @@ export default class WebSlides {
       requestFullscreen.call(el);
     } else {
       const cancelFullscreen = document.exitFullScreen
-        || document.mozCancelFullScreen
         || document.webkitCancelFullScreen
+        || document.mozCancelFullScreen
         || document.msExitFullscreen;
 
       cancelFullscreen.call(document);

--- a/src/js/modules/webslides.js
+++ b/src/js/modules/webslides.js
@@ -418,6 +418,32 @@ export default class WebSlides {
   }
 
   /**
+   * Puts the browser into fullscreen
+   */
+  fullscreen() {
+    const el = document.documentElement;
+    const isFullscreen = document.fullscreen
+      || document.mozFullScreen
+      || document.webkitIsFullScreen
+      || document.msFullScreenElement;
+
+    if(!isFullscreen) {
+      const requestFullscreen = el.requestFullscreen
+          || el.webkitRequestFullScreen
+          || el.mozRequestFullScreen
+          || el.msRequestFullscreen;
+      requestFullscreen.call(el);
+    } else {
+      const cancelFullscreen = document.exitFullScreen
+        || document.mozCancelFullScreen
+        || document.webkitCancelFullScreen
+        || document.msExitFullscreen;
+
+      cancelFullscreen.call(document);
+    }
+  }
+
+  /**
    * Registers a plugin to be loaded when the instance is created. It allows
    * (on purpose) to replace default plugins.
    * @param {!string} key They key under which it'll be stored inside of the

--- a/src/js/plugins/keyboard.js
+++ b/src/js/plugins/keyboard.js
@@ -61,6 +61,9 @@ export default class Keyboard {
       case Keys.RIGHT:
         method = !this.ws_.isVertical ? this.ws_.goNext : null;
         break;
+      case Keys.F:
+        method = this.ws_.fullscreen;
+        break;
     }
 
     if (method) {

--- a/src/js/utils/keys.js
+++ b/src/js/utils/keys.js
@@ -11,7 +11,8 @@ const Keys = {
   DOWN: 40,
   PLUS: [107, 171],
   MINUS: [109, 173],
-  ESCAPE: 27
+  ESCAPE: 27,
+  F: 70
 };
 
 export default Keys;

--- a/test/modules/webslides.test.js
+++ b/test/modules/webslides.test.js
@@ -73,14 +73,13 @@ test('WebSlides utility', () => {
   webslides.enable();
   expect(webslides.isDisabled()).toBe(false);
 
-  const requestFullscreenMock = jest.fn();
-  const exitFullScreenMock = jest.fn();
+
   document.fullscreen = false;
-  document.documentElement.requestFullscreen = requestFullscreenMock;
-  document.exitFullScreen = exitFullScreenMock;
+  document.documentElement.requestFullscreen = jest.fn();
+  document.exitFullScreen = jest.fn();
   webslides.fullscreen();
-  expect(requestFullscreenMock.mock.calls.length).toBe(1);
+  expect(document.documentElement.requestFullscreen.mock.calls.length).toBe(1);
   document.fullscreen = true;
   webslides.fullscreen();
-  expect(exitFullScreenMock.mock.calls.length).toBe(1);
+  expect(document.exitFullScreen.mock.calls.length).toBe(1);
 });

--- a/test/modules/webslides.test.js
+++ b/test/modules/webslides.test.js
@@ -72,4 +72,15 @@ test('WebSlides utility', () => {
   expect(webslides.isDisabled()).toBe(true);
   webslides.enable();
   expect(webslides.isDisabled()).toBe(false);
+
+  const requestFullscreenMock = jest.fn();
+  const exitFullScreenMock = jest.fn();
+  document.fullscreen = false;
+  document.documentElement.requestFullscreen = requestFullscreenMock;
+  document.exitFullScreen = exitFullScreenMock;
+  webslides.fullscreen();
+  expect(requestFullscreenMock.mock.calls.length).toBe(1);
+  document.fullscreen = true;
+  webslides.fullscreen();
+  expect(exitFullScreenMock.mock.calls.length).toBe(1);
 });

--- a/test/plugins/keyboard.test.js
+++ b/test/plugins/keyboard.test.js
@@ -22,6 +22,7 @@ test('Keyboard plugin', () => {
   const goto = jest.fn();
   const next = jest.fn();
   const prev = jest.fn();
+  const fullscreen = jest.fn();
   const ws = document.getElementById('webslides');
 
   let disabled = true;
@@ -31,6 +32,7 @@ test('Keyboard plugin', () => {
     goNext: next,
     goPrev: prev,
     isVertical: false,
+    fullscreen: fullscreen,
     isDisabled: () => disabled,
     el: ws
   };
@@ -61,4 +63,6 @@ test('Keyboard plugin', () => {
   expect(prev.mock.calls.length).toBe(2);
   simulateKeyEvent(document, Keys.RIGHT);
   expect(next.mock.calls.length).toBe(3);
+  simulateKeyEvent(document, Keys.F);
+  expect(fullscreen.mock.calls.length).toBe(1);
 });


### PR DESCRIPTION
I've missed the functionality of going fullscreen. I don't like to see browser window when doing my presentations, so I created the functionality of going fullscreen using Fullscreen API.

To make it work you just need to push F key. Maybe this is not the perfect key assignment, suggestions welcome.