### PR TITLE
removing reference to non-existant file

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -36,11 +36,6 @@ webslides.js will add .ws-ready automatically. Don't worry :) -- */
   }
 }
 
-/* -- Prototype faster - Vertical rhythm  -- */
-.baseline {
-  background: url('../images/baseline.png') left top .8rem/.8rem;
-}
-
 li li {
   margin-left: 1.6rem;
 }

--- a/static/css/webslides.css
+++ b/static/css/webslides.css
@@ -1,7 +1,7 @@
 /*!
  * Name: WebSlides
  * Version: 1.4.1
- * Date: 2017-08-18
+ * Date: 2017-09-01
  * Description: Making HTML presentations easy
  * URL: https://github.com/webslides/webslides#readme
  * Credits: @jlantunez, @LuisSacristan, @Belelros
@@ -363,10 +363,6 @@ webslides.js will add .ws-ready automatically. Don't worry :) -- */
   overflow-y: scroll; }
   #webslides::-webkit-scrollbar {
     display: none; }
-
-/* -- Prototype faster - Vertical rhythm  -- */
-.baseline {
-  background: url("../images/baseline.png") left top 0.8rem/0.8rem; }
 
 li li {
   margin-left: 1.6rem; }

--- a/static/js/webslides.js
+++ b/static/js/webslides.js
@@ -1,7 +1,7 @@
 /*!
  * Name: WebSlides
  * Version: 1.4.1
- * Date: 2017-08-18
+ * Date: 2017-09-01
  * Description: Making HTML presentations easy
  * URL: https://github.com/webslides/webslides#readme
  * Credits: @jlantunez, @LuisSacristan, @Belelros

--- a/static/js/webslides.min.js
+++ b/static/js/webslides.min.js
@@ -1,7 +1,7 @@
 /*!
  * Name: WebSlides
  * Version: 1.4.1
- * Date: 2017-08-18
+ * Date: 2017-09-01
  * Description: Making HTML presentations easy
  * URL: https://github.com/webslides/webslides#readme
  * Credits: @jlantunez, @LuisSacristan, @Belelros


### PR DESCRIPTION
Hi there!

I ran into an issue while using webslides in an existing webpack project. There was a reference in the css to a `baseline.png` which wasn't in the repo. Since all the css class did was set the background to that image, I took it out.

That said, I'm not sure what it was for, so a better solution might be to add the image back into the repo.