### PR TITLE
Don't publish .babelrc file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/package.json
+++ b/package.json
@@ -85,16 +85,6 @@
   "pre-commit": [
     "lint"
   ],
-  "babel": {
-    "presets": [
-      [
-        "es2015",
-        {
-          "modules": false
-        }
-      ]
-    ]
-  },
   "dependencies": {
     "request": "^2.83.0"
   }


### PR DESCRIPTION
More and more npm packages contain ES2015+ code.
As discussed in [this AMA](https://github.com/sindresorhus/ama/issues/446), this causes a lot of troubles (Uglify and old browsers) for people.

One possible solution is to transpile external dependencies, as discussed in [this issue on create-react-app](https://github.com/facebookincubator/create-react-app/issues/1125) and implemented in [this pull request](https://github.com/facebookincubator/create-react-app/pull/3776).

This doesn't currently work with Webslides as the .babelrc file is published on npm.
Here is a [small repo demonstrating the bug](https://github.com/oligot/webslides-babelrc).
Running `npm run build` results in this error

```
ERROR in ./node_modules/webslides/static/js/webslides.js
Module build failed: Error: Couldn't find preset "es2015" relative to directory ".../webslides-babelrc/node_modules/webslides"
```

By adding the .babelrc file to .npmignore, and removing the babel config in the _package.json_ file, the bug would go away once a new version of Webslides is published.

This is basically the same PR as done for [v-tooltip](https://github.com/Akryum/v-tooltip/pull/90).