### PR TITLE
Extend detail object to solve #127 and maybe to approach #71

### DIFF
--- a/src/js/modules/slide.js
+++ b/src/js/modules/slide.js
@@ -37,6 +37,18 @@ class Slide {
      */
     this.i = i;
 
+    /**
+     * The slide name if there is any.
+     * @type {string}
+     */
+    this.slideName = this.el.getAttribute('slideName');
+
+    /**
+     * The slide id if there is any.
+     * @type {string}
+     */
+    this.id = this.el.getAttribute('id');
+
     this.el.id = this.el.id ? this.el.id : `section-${(i + 1)}`;
     this.el.classList.add(CLASSES.SLIDE);
 

--- a/src/js/modules/webslides.js
+++ b/src/js/modules/webslides.js
@@ -89,6 +89,18 @@ export default class WebSlides {
      */
     this.currentSlide_ = null;
     /**
+     Name of the Slide.
+     * @type {string}
+     * @private
+     */
+    this.slideName = null;
+    /**
+     ID of the Slide.
+     * @type {string}
+     * @private
+     */
+    this.id = null;
+    /**
      * Max slide index.
      * @type {number}
      * @private
@@ -316,7 +328,9 @@ export default class WebSlides {
     DOM.fireEvent(this.el, 'ws:slide-change', {
       slides: this.maxSlide_,
       currentSlide0: this.currentSlideI_,
-      currentSlide: this.currentSlideI_ + 1
+      currentSlide: this.currentSlideI_ + 1,
+      slideName: slide.slideName,
+      id: slide.id
     });
   }
 


### PR DESCRIPTION
I extended the detail object when listening to the event `ws:slide-change`. For developing a plugin or a custom javascript snippet, it is better to get more information of the slide such as ID or a slide name.